### PR TITLE
Tweaks

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,7 +49,7 @@ jobs:
       run: msbuild src\modules\launcher\Wox.Infrastructure\ -t:Restore /p:Platform=${{matrix.platform}}
 
     - name: Build
-      run: msbuild src\modules\launcher\Wox.Infrastructure\ /p:Configuration=Release /p:Platform=${{matrix.platform}} /p:Version=${{env.PowerToys_Version}}
+      run: msbuild src\modules\launcher\Wox.Infrastructure\ /p:Configuration=Release /p:Platform=${{matrix.platform}} /p:Version=${{env.PowerToys_Version}} /p:Deterministic=true /p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,7 +49,7 @@ jobs:
       run: msbuild src\modules\launcher\Wox.Infrastructure\ -t:Restore /p:Platform=${{matrix.platform}}
 
     - name: Build
-      run: msbuild src\modules\launcher\Wox.Infrastructure\ /p:Configuration=Release /p:Platform=${{matrix.platform}} /p:Version=${{env.PowerToys_Version}} /p:Deterministic=true /p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true
+      run: msbuild src\modules\launcher\Wox.Infrastructure\ /p:Configuration=Release /p:Platform=${{matrix.platform}} /p:Version=${{env.PowerToys_Version}}.0 /p:Deterministic=true /p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -91,10 +91,5 @@ jobs:
     - name: Pack
       run: dotnet build main -c Release /p:Version=${{needs.build.outputs.PowerToys_Version}}
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Package
-        path: main\bin\Release\*.nupkg
-
-    # - name: NuGet Push
-    #   run: dotnet nuget push main\bin\Release\*.nupkg --api-key "${{secrets.NUGET_APIKEY}}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+    - name: NuGet Push
+      run: dotnet nuget push main\bin\Release\*.nupkg --api-key "${{secrets.NUGET_APIKEY}}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -91,5 +91,10 @@ jobs:
     - name: Pack
       run: dotnet build main -c Release /p:Version=${{needs.build.outputs.PowerToys_Version}}
 
-    - name: NuGet Push
-      run: dotnet nuget push main\bin\Release\*.nupkg --api-key "${{secrets.NUGET_APIKEY}}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Package
+        path: main\bin\Release\*.nupkg
+
+    # - name: NuGet Push
+    #   run: dotnet nuget push main\bin\Release\*.nupkg --api-key "${{secrets.NUGET_APIKEY}}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Community.PowerToys.Run.Plugin.Dependencies.csproj
+++ b/Community.PowerToys.Run.Plugin.Dependencies.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <Version>$(Version).0</Version>
+    <Version>$(Version)</Version>
     <Authors>Henrik Lau Eriksson</Authors>
     <Description>This NuGet package simplifies referencing all PowerToys Run Plugin dependencies.
 

--- a/Community.PowerToys.Run.Plugin.Dependencies.csproj
+++ b/Community.PowerToys.Run.Plugin.Dependencies.csproj
@@ -33,24 +33,25 @@ It contains the ARM64 and x64 versions of:
     <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="Community.PowerToys.Run.Plugin.Dependencies.props" Pack="true" PackagePath="buildTransitive\Community.PowerToys.Run.Plugin.Dependencies.props" />
+    <None Include="Community.PowerToys.Run.Plugin.Dependencies.targets" Pack="true" PackagePath="buildTransitive\Community.PowerToys.Run.Plugin.Dependencies.targets" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="tools\ARM64" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="runtimes\win-arm64\native" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="runtimes\win-arm64\native" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="tools\x64" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="runtimes\win-x64\native" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="runtimes\win-x64\native" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="runtimes\win-x64\native" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="runtimes\win-x64\native" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="runtimes\win-x64\native" />
   </ItemGroup>
 
 </Project>

--- a/Community.PowerToys.Run.Plugin.Dependencies.csproj
+++ b/Community.PowerToys.Run.Plugin.Dependencies.csproj
@@ -26,6 +26,10 @@ It contains the ARM64 and x64 versions of:
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="Community.PowerToys.Run.Plugin.Dependencies.props" Pack="true" PackagePath="buildTransitive\Community.PowerToys.Run.Plugin.Dependencies.props" />

--- a/Community.PowerToys.Run.Plugin.Dependencies.csproj
+++ b/Community.PowerToys.Run.Plugin.Dependencies.csproj
@@ -32,19 +32,21 @@ It contains the ARM64 and x64 versions of:
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Common.UI.dll" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.ManagedCommon.dll" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.dll" Pack="true" PackagePath="tools\ARM64" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="tools\ARM64" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="tools\ARM64" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="tools\ARM64" />
     <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="tools\ARM64" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Plugin.dll" Pack="true" PackagePath="tools\ARM64" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="tools\ARM64" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="tools\ARM64" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Common.UI.dll" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.ManagedCommon.dll" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.dll" Pack="true" PackagePath="tools\x64" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="tools\x64" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="tools\x64" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="tools\x64" />
     <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="tools\x64" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Plugin.dll" Pack="true" PackagePath="tools\x64" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="tools\x64" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="tools\x64" />
   </ItemGroup>
 
 </Project>

--- a/Community.PowerToys.Run.Plugin.Dependencies.csproj
+++ b/Community.PowerToys.Run.Plugin.Dependencies.csproj
@@ -23,6 +23,7 @@ It contains the ARM64 and x64 versions of:
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Community.PowerToys.Run.Plugin.Dependencies.csproj
+++ b/Community.PowerToys.Run.Plugin.Dependencies.csproj
@@ -37,21 +37,21 @@ It contains the ARM64 and x64 versions of:
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="runtimes\win-arm64\native" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="runtimes\win-arm64\native" />
-    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="runtimes\win-arm64\native" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="runtimes\win-arm64\lib\net8.0" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="runtimes\win-arm64\lib\net8.0" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="runtimes\win-arm64\lib\net8.0" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="runtimes\win-arm64\lib\net8.0" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="runtimes\win-arm64\lib\net8.0" />
+    <None Include="..\PowerToys\ARM64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="runtimes\win-arm64\lib\net8.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="runtimes\win-x64\native" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Common.UI.*" Pack="true" PackagePath="runtimes\win-x64\lib\net8.0" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.ManagedCommon.*" Pack="true" PackagePath="runtimes\win-x64\lib\net8.0" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\PowerToys.Settings.UI.Lib.*" Pack="true" PackagePath="runtimes\win-x64\lib\net8.0" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.dll" Pack="true" PackagePath="runtimes\win-x64\lib\net8.0" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Infrastructure.pdb" Pack="true" PackagePath="runtimes\win-x64\lib\net8.0" />
+    <None Include="..\PowerToys\x64\Release\WoxInfrastructure\Wox.Plugin.*" Pack="true" PackagePath="runtimes\win-x64\lib\net8.0" />
   </ItemGroup>
 
 </Project>

--- a/Community.PowerToys.Run.Plugin.Dependencies.props
+++ b/Community.PowerToys.Run.Plugin.Dependencies.props
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(Platform)' == 'ARM64'">
-    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\ARM64\PowerToys.Common.UI.dll" />
-    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\ARM64\PowerToys.ManagedCommon.dll" />
-    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\ARM64\PowerToys.Settings.UI.Lib.dll" />
-    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\ARM64\Wox.Infrastructure.dll" />
-    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\ARM64\Wox.Plugin.dll" />
+    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\PowerToys.Common.UI.dll" />
+    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\PowerToys.ManagedCommon.dll" />
+    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\PowerToys.Settings.UI.Lib.dll" />
+    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\Wox.Infrastructure.dll" />
+    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\Wox.Plugin.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Platform)' == 'x64'">
-    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\x64\PowerToys.Common.UI.dll" />
-    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\x64\PowerToys.ManagedCommon.dll" />
-    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\x64\PowerToys.Settings.UI.Lib.dll" />
-    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\x64\Wox.Infrastructure.dll" />
-    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\tools\x64\Wox.Plugin.dll" />
+  <ItemGroup Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'AnyCPU'">
+    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\PowerToys.Common.UI.dll" />
+    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\PowerToys.ManagedCommon.dll" />
+    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\PowerToys.Settings.UI.Lib.dll" />
+    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\Wox.Infrastructure.dll" />
+    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\Wox.Plugin.dll" />
   </ItemGroup>
 </Project>

--- a/Community.PowerToys.Run.Plugin.Dependencies.props
+++ b/Community.PowerToys.Run.Plugin.Dependencies.props
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(Platform)' == 'ARM64'">
-    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\PowerToys.Common.UI.dll" />
-    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\PowerToys.ManagedCommon.dll" />
-    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\PowerToys.Settings.UI.Lib.dll" />
-    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\Wox.Infrastructure.dll" />
-    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\Wox.Plugin.dll" />
+    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\lib\net8.0\PowerToys.Common.UI.dll" />
+    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\lib\net8.0\PowerToys.ManagedCommon.dll" />
+    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\lib\net8.0\PowerToys.Settings.UI.Lib.dll" />
+    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\lib\net8.0\Wox.Infrastructure.dll" />
+    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\lib\net8.0\Wox.Plugin.dll" />
   </ItemGroup>
   <ItemGroup Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'AnyCPU'">
-    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\PowerToys.Common.UI.dll" />
-    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\PowerToys.ManagedCommon.dll" />
-    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\PowerToys.Settings.UI.Lib.dll" />
-    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\Wox.Infrastructure.dll" />
-    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\Wox.Plugin.dll" />
+    <Reference Include="PowerToys.Common.UI.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\lib\net8.0\PowerToys.Common.UI.dll" />
+    <Reference Include="PowerToys.ManagedCommon.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\lib\net8.0\PowerToys.ManagedCommon.dll" />
+    <Reference Include="PowerToys.Settings.UI.Lib.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\lib\net8.0\PowerToys.Settings.UI.Lib.dll" />
+    <Reference Include="Wox.Infrastructure.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\lib\net8.0\Wox.Infrastructure.dll" />
+    <Reference Include="Wox.Plugin.dll" HintPath="$(MSBuildThisFileDirectory)..\runtimes\win-x64\lib\net8.0\Wox.Plugin.dll" />
   </ItemGroup>
 </Project>

--- a/Community.PowerToys.Run.Plugin.Dependencies.targets
+++ b/Community.PowerToys.Run.Plugin.Dependencies.targets
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\*.*" Condition="'$(Platform)' == 'ARM64'" />
+    <NativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\*.*" Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'AnyCPU'" />
+    <ContentWithTargetPath Include="@(NativeLibs)">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
+</Project>

--- a/Community.PowerToys.Run.Plugin.Dependencies.targets
+++ b/Community.PowerToys.Run.Plugin.Dependencies.targets
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\*.*" Condition="'$(Platform)' == 'ARM64'" />
-    <NativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\*.*" Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'AnyCPU'" />
-    <ContentWithTargetPath Include="@(NativeLibs)">
+    <PowerToysLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\lib\net8.0\*.*" Condition="'$(Platform)' == 'ARM64'" />
+    <PowerToysLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\lib\net8.0\*.*" Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'AnyCPU'" />
+    <ContentWithTargetPath Include="@(PowerToysLibs)">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>


### PR DESCRIPTION
Changes:

- Add SourceLink
- Build PowerToys DLLs with four-part version number
- Add build properties for PowerToys DLLs:
```
Deterministic=true
ContinuousIntegrationBuild=true
EmbedUntrackedSources=true
```
- Move PowerToys DLLs to architecture-specific folders:
```
\runtimes
  \win-arm64
    \lib\net8.0
  \win-x64
    \lib\net8.0
```
- Add `.targets` file that will copy PowerToys DLLs to the output directory
